### PR TITLE
Add Cipher Notes v1.4.1 static app prototype and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,75 +1,43 @@
-<header>
+<div align="center">
 
-<!--
-  <<< Author notes: Course header >>>
-  Include a 1280×640 image, course title in sentence case, and a concise description in emphasis.
-  In your repository settings: enable template repository, add your 1280×640 social image, auto delete head branches.
-  Add your open source license, GitHub uses MIT license.
--->
+# CIPHER NOTES // GITHUB → APP
 
-# Introduction to GitHub
+### A neon-grade local notes app prototype for **CipherNotes v1.4.1**
 
-_Get started using GitHub in less than an hour._
+[![Release](https://img.shields.io/badge/release-v1.4.1-00f5ff?style=for-the-badge&logo=github&logoColor=white&labelColor=050816)](https://github.com/CipherApps/cipher-notes/releases/tag/v1.4.1)
+[![Status](https://img.shields.io/badge/status-app_prototype-ff2bd6?style=for-the-badge&labelColor=050816)](./index.html)
+[![Platform](https://img.shields.io/badge/pipeline-GitHub_to_App-8cff00?style=for-the-badge&logo=githubactions&logoColor=white&labelColor=050816)](https://github.com/CipherApps/cipher-notes)
 
-</header>
+</div>
 
-<!--
-  <<< Author notes: Step 1 >>>
-  Choose 3-5 steps for your course.
-  The first step is always the hardest, so pick something easy!
-  Link to docs.github.com for further explanations.
-  Encourage users to open new tabs for steps!
--->
+## What changed
 
-## Step 1: Create a branch
+This repository now contains a runnable static web app instead of only a release landing page. The prototype gives **Cipher Notes (GitHub to App)** a cybernetic command-deck interface for writing, tagging, prioritizing, saving, deleting, and exporting local notes.
 
-_Welcome to "Introduction to GitHub"! :wave:_
+## Run the app
 
-**What is GitHub?**: GitHub is a collaboration platform that uses _[Git](https://docs.github.com/get-started/quickstart/github-glossary#git)_ for versioning. GitHub is a popular place to share and contribute to [open-source](https://docs.github.com/get-started/quickstart/github-glossary#open-source) software.
-<br>:tv: [Video: What is GitHub?](https://www.youtube.com/watch?v=pBy1zgt0XPc)
+Open `index.html` directly in a browser, or serve the folder with any static file server:
 
-**What is a repository?**: A _[repository](https://docs.github.com/get-started/quickstart/github-glossary#repository)_ is a project containing files and folders. A repository tracks versions of files and folders. For more information, see "[About repositories](https://docs.github.com/en/repositories/creating-and-managing-repositories/about-repositories)" from GitHub Docs.
+```bash
+python3 -m http.server 4173
+```
 
-**What is a branch?**: A _[branch](https://docs.github.com/en/get-started/quickstart/github-glossary#branch)_ is a parallel version of your repository. By default, your repository has one branch named `main` and it is considered to be the definitive branch. Creating additional branches allows you to copy the `main` branch of your repository and safely make any changes without disrupting the main project. Many people use branches to work on specific features without affecting any other parts of the project.
+Then visit <http://localhost:4173>.
 
-Branches allow you to separate your work from the `main` branch. In other words, everyone's work is safe while you contribute. For more information, see "[About branches](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-branches)".
+## App features
 
-**What is a profile README?**: A _[profile README](https://docs.github.com/account-and-profile/setting-up-and-managing-your-github-profile/customizing-your-profile/managing-your-profile-readme)_ is essentially an "About me" section on your GitHub profile where you can share information about yourself with the community on GitHub.com. GitHub shows your profile README at the top of your profile page. For more information, see "[Managing your profile README](https://docs.github.com/en/account-and-profile/setting-up-and-managing-your-github-profile/customizing-your-profile/managing-your-profile-readme)".
+- **Cybernetic vault rail:** browse saved signals with priority, tag, and last-updated metadata.
+- **Autosaving editor:** every title, body, priority, and tag update persists to `localStorage`.
+- **Launch-ready starter notes:** preloaded v1.4.1 and roadmap notes make the app feel alive immediately.
+- **Portable export:** download the full vault as JSON for the next native or hosted app iteration.
+- **Release uplink:** jump from the app shell to the official CipherNotes v1.4.1 GitHub release.
 
-![profile-readme-example](/images/profile-readme-example.png)
+## Mission brief
 
-### :keyboard: Activity: Your first branch
+Version **v1.4.1** is represented as a hotfix-focused release path from GitHub into an app experience. The interface keeps the previous cyberpunk identity while adding functional app behavior: local persistence, editing workflow, diagnostics, and export.
 
-1. Open a new browser tab and navigate to your newly made repository. Then, work on the steps in your second tab while you read the instructions in this tab.
-2. Navigate to the **< > Code** tab in the header menu of your repository.
+## Project files
 
-   ![code-tab](/images/code-tab.png)
-
-3. Click on the **main** branch drop-down.
-
-   ![main-branch-dropdown](/images/main-branch-dropdown.png)
-
-4. In the field, enter a name for your branch: `my-first-branch`.
-5. Click **Create branch: my-first-branch** to create your branch.
-
-   ![create-branch-button](/images/create-branch-button.png)
-
-   The branch will automatically switch to the one you have just created.
-   The **main** branch drop-down bar will reflect your new branch and display the new branch name.
-
-6. Wait about 20 seconds then refresh this page (the one you're following instructions from). [GitHub Actions](https://docs.github.com/en/actions) will automatically update to the next step.
-
-<footer>
-
-<!--
-  <<< Author notes: Footer >>>
-  Add a link to get support, GitHub status page, code of conduct, license link.
--->
-
----
-
-Get help: [Post in our discussion board](https://github.com/skills/.github/discussions) &bull; [Review the GitHub status page](https://www.githubstatus.com/)
-
-&copy; 2023 GitHub &bull; [Code of Conduct](https://www.contributor-covenant.org/version/2/1/code_of_conduct/code_of_conduct.md) &bull; [MIT License](https://gh.io/mit)
-
-</footer>
+- `index.html` — app structure and semantic interface regions.
+- `styles.css` — cybernetic visual system, responsive layout, and neon controls.
+- `app.js` — note state, local persistence, rendering, create/delete, and JSON export.

--- a/app.js
+++ b/app.js
@@ -1,0 +1,202 @@
+const STORAGE_KEY = "cipher-notes-v1";
+
+const starterNotes = [
+  {
+    id: crypto.randomUUID(),
+    title: "Launch v1.4.1",
+    body: "Verify the EditorScreen hotfix, download the release artifact, and route the signal from GitHub into the app cockpit.",
+    priority: "high",
+    tag: "release",
+    updatedAt: new Date().toISOString(),
+  },
+  {
+    id: crypto.randomUUID(),
+    title: "Cybernetic upgrade ideas",
+    body: "Add encrypted sync, biometric unlock, a graph view for connected notes, and a glitch-mode focus timer.",
+    priority: "medium",
+    tag: "roadmap",
+    updatedAt: new Date(Date.now() - 1000 * 60 * 24).toISOString(),
+  },
+];
+
+const elements = {
+  activeNoteStatus: document.querySelector("#activeNoteStatus"),
+  deleteButton: document.querySelector("#deleteButton"),
+  exportButton: document.querySelector("#exportButton"),
+  form: document.querySelector("#noteForm"),
+  newNoteButton: document.querySelector("#newNoteButton"),
+  noteBody: document.querySelector("#noteBody"),
+  noteCount: document.querySelector("#noteCount"),
+  notePriority: document.querySelector("#notePriority"),
+  notesList: document.querySelector("#notesList"),
+  noteTag: document.querySelector("#noteTag"),
+  noteTitle: document.querySelector("#noteTitle"),
+  syncStatus: document.querySelector("#syncStatus"),
+  wordCount: document.querySelector("#wordCount"),
+};
+
+let notes = loadNotes();
+let activeNoteId = notes[0]?.id;
+
+function loadNotes() {
+  const savedNotes = localStorage.getItem(STORAGE_KEY);
+
+  if (!savedNotes) {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(starterNotes));
+    return starterNotes;
+  }
+
+  try {
+    const parsedNotes = JSON.parse(savedNotes);
+    return Array.isArray(parsedNotes) && parsedNotes.length > 0 ? parsedNotes : starterNotes;
+  } catch {
+    return starterNotes;
+  }
+}
+
+function saveNotes() {
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(notes));
+  elements.syncStatus.textContent = "saved";
+  window.setTimeout(() => {
+    elements.syncStatus.textContent = "local";
+  }, 900);
+}
+
+function getActiveNote() {
+  return notes.find((note) => note.id === activeNoteId) ?? notes[0];
+}
+
+function countWords() {
+  return notes.reduce((total, note) => {
+    const words = `${note.title} ${note.body}`.trim().split(/\s+/).filter(Boolean);
+    return total + words.length;
+  }, 0);
+}
+
+function formatTimestamp(isoDate) {
+  return new Intl.DateTimeFormat("en", {
+    dateStyle: "medium",
+    timeStyle: "short",
+  }).format(new Date(isoDate));
+}
+
+function renderNotesList() {
+  elements.notesList.innerHTML = "";
+
+  [...notes]
+    .sort((a, b) => new Date(b.updatedAt) - new Date(a.updatedAt))
+    .forEach((note) => {
+      const button = document.createElement("button");
+      const title = document.createElement("strong");
+      const meta = document.createElement("small");
+      const timestamp = document.createElement("small");
+
+      button.className = `note-card${note.id === activeNoteId ? " active" : ""}`;
+      button.type = "button";
+      title.textContent = note.title || "Untitled signal";
+      meta.textContent = `${note.priority.toUpperCase()} // ${note.tag || "untagged"}`;
+      timestamp.textContent = formatTimestamp(note.updatedAt);
+
+      button.append(title, meta, timestamp);
+      button.addEventListener("click", () => {
+        activeNoteId = note.id;
+        render();
+      });
+      elements.notesList.append(button);
+    });
+}
+
+function renderEditor() {
+  const activeNote = getActiveNote();
+  if (!activeNote) return;
+
+  activeNoteId = activeNote.id;
+  elements.noteTitle.value = activeNote.title;
+  elements.noteBody.value = activeNote.body;
+  elements.notePriority.value = activeNote.priority;
+  elements.noteTag.value = activeNote.tag;
+  elements.activeNoteStatus.textContent = `${activeNote.title || "Untitled signal"} // ${activeNote.priority} // ${activeNote.tag || "untagged"}`;
+}
+
+function renderStats() {
+  elements.noteCount.textContent = notes.length;
+  elements.wordCount.textContent = countWords();
+}
+
+function render() {
+  renderNotesList();
+  renderEditor();
+  renderStats();
+}
+
+function updateActiveNote() {
+  const activeNote = getActiveNote();
+  if (!activeNote) return;
+
+  activeNote.title = elements.noteTitle.value;
+  activeNote.body = elements.noteBody.value;
+  activeNote.priority = elements.notePriority.value;
+  activeNote.tag = elements.noteTag.value;
+  activeNote.updatedAt = new Date().toISOString();
+
+  saveNotes();
+  renderNotesList();
+  renderStats();
+  elements.activeNoteStatus.textContent = `${activeNote.title || "Untitled signal"} // ${activeNote.priority} // ${activeNote.tag || "untagged"}`;
+}
+
+function createNote() {
+  const note = {
+    id: crypto.randomUUID(),
+    title: "Untitled signal",
+    body: "",
+    priority: "medium",
+    tag: "inbox",
+    updatedAt: new Date().toISOString(),
+  };
+  notes = [note, ...notes];
+  activeNoteId = note.id;
+  saveNotes();
+  render();
+  elements.noteTitle.focus();
+  elements.noteTitle.select();
+}
+
+function deleteActiveNote() {
+  if (notes.length === 1) {
+    notes = [
+      {
+        id: crypto.randomUUID(),
+        title: "Fresh signal",
+        body: "",
+        priority: "low",
+        tag: "inbox",
+        updatedAt: new Date().toISOString(),
+      },
+    ];
+  } else {
+    notes = notes.filter((note) => note.id !== activeNoteId);
+  }
+
+  activeNoteId = notes[0].id;
+  saveNotes();
+  render();
+}
+
+function exportNotes() {
+  const payload = JSON.stringify({ exportedAt: new Date().toISOString(), notes }, null, 2);
+  const blob = new Blob([payload], { type: "application/json" });
+  const url = URL.createObjectURL(blob);
+  const anchor = document.createElement("a");
+  anchor.href = url;
+  anchor.download = "cipher-notes-export.json";
+  anchor.click();
+  URL.revokeObjectURL(url);
+}
+
+elements.form.addEventListener("input", updateActiveNote);
+elements.newNoteButton.addEventListener("click", createNote);
+elements.deleteButton.addEventListener("click", deleteActiveNote);
+elements.exportButton.addEventListener("click", exportNotes);
+
+render();

--- a/index.html
+++ b/index.html
@@ -1,0 +1,109 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Cipher Notes // GitHub to App</title>
+    <meta
+      name="description"
+      content="A cybernetic local-first notes app prototype inspired by CipherNotes v1.4.1."
+    />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700;800&family=JetBrains+Mono:wght@400;600;700&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <div class="grid-glow" aria-hidden="true"></div>
+    <main class="app-shell">
+      <aside class="sidebar" aria-label="Cipher Notes navigation">
+        <section class="brand-card">
+          <p class="eyebrow">GitHub → App</p>
+          <h1>Cipher Notes</h1>
+          <p class="brand-copy">
+            A neon command deck for private fragments, launch plans, and encrypted thought streams.
+          </p>
+          <a
+            class="release-link"
+            href="https://github.com/CipherApps/cipher-notes/releases/tag/v1.4.1"
+            target="_blank"
+            rel="noreferrer"
+          >
+            v1.4.1 release uplink ↗
+          </a>
+        </section>
+
+        <section class="stats-grid" aria-label="Note statistics">
+          <article>
+            <span id="noteCount">0</span>
+            <small>notes</small>
+          </article>
+          <article>
+            <span id="wordCount">0</span>
+            <small>words</small>
+          </article>
+          <article>
+            <span id="syncStatus">local</span>
+            <small>vault</small>
+          </article>
+        </section>
+
+        <button id="newNoteButton" class="primary-action" type="button">+ New signal</button>
+        <div id="notesList" class="notes-list" aria-live="polite"></div>
+      </aside>
+
+      <section class="workspace" aria-label="Cipher note editor">
+        <header class="topbar">
+          <div>
+            <p class="eyebrow">Cybernetic editor cortex</p>
+            <h2>Write. Classify. Lock into local storage.</h2>
+          </div>
+          <div class="topbar-actions">
+            <button id="exportButton" class="ghost-button" type="button">Export JSON</button>
+            <button id="deleteButton" class="danger-button" type="button">Delete</button>
+          </div>
+        </header>
+
+        <form id="noteForm" class="editor-card">
+          <label for="noteTitle">Signal title</label>
+          <input id="noteTitle" name="title" type="text" autocomplete="off" />
+
+          <div class="meta-row">
+            <label>
+              Priority
+              <select id="notePriority" name="priority">
+                <option value="low">Low orbit</option>
+                <option value="medium">Medium pulse</option>
+                <option value="high">High voltage</option>
+              </select>
+            </label>
+            <label>
+              Tag
+              <input id="noteTag" name="tag" type="text" autocomplete="off" />
+            </label>
+          </div>
+
+          <label for="noteBody">Encrypted thought stream</label>
+          <textarea id="noteBody" name="body" rows="16"></textarea>
+        </form>
+
+        <section class="transmission-panel" aria-label="App diagnostics">
+          <div>
+            <p class="eyebrow">Diagnostic readout</p>
+            <h3 id="activeNoteStatus">No signal selected</h3>
+          </div>
+          <ul>
+            <li>Autosaves every keystroke to this browser.</li>
+            <li>Highlights the active signal in the vault rail.</li>
+            <li>Exports a portable JSON payload for your next app iteration.</li>
+          </ul>
+        </section>
+      </section>
+    </main>
+
+    <script src="app.js" defer></script>
+  </body>
+</html>

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,343 @@
+:root {
+  color-scheme: dark;
+  --bg: #050712;
+  --panel: rgba(10, 16, 34, 0.82);
+  --panel-strong: rgba(15, 24, 52, 0.95);
+  --cyan: #00f5ff;
+  --pink: #ff2bd6;
+  --lime: #8cff00;
+  --amber: #ffd166;
+  --text: #edf7ff;
+  --muted: #9db0c8;
+  --line: rgba(0, 245, 255, 0.22);
+  --danger: #ff5470;
+  font-family: Inter, system-ui, sans-serif;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-height: 100vh;
+  margin: 0;
+  background:
+    radial-gradient(circle at top left, rgba(255, 43, 214, 0.2), transparent 32rem),
+    radial-gradient(circle at bottom right, rgba(0, 245, 255, 0.2), transparent 34rem),
+    var(--bg);
+  color: var(--text);
+}
+
+button,
+input,
+select,
+textarea {
+  font: inherit;
+}
+
+button {
+  cursor: pointer;
+}
+
+.grid-glow {
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  background-image:
+    linear-gradient(rgba(0, 245, 255, 0.05) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(0, 245, 255, 0.05) 1px, transparent 1px);
+  background-size: 48px 48px;
+  mask-image: linear-gradient(to bottom, rgba(0, 0, 0, 0.9), transparent);
+}
+
+.app-shell {
+  position: relative;
+  display: grid;
+  grid-template-columns: 360px minmax(0, 1fr);
+  gap: 1.5rem;
+  width: min(1440px, calc(100% - 2rem));
+  min-height: calc(100vh - 2rem);
+  margin: 1rem auto;
+}
+
+.sidebar,
+.workspace,
+.editor-card,
+.transmission-panel {
+  border: 1px solid var(--line);
+  box-shadow: 0 0 32px rgba(0, 245, 255, 0.08), inset 0 0 32px rgba(255, 43, 214, 0.03);
+  backdrop-filter: blur(18px);
+}
+
+.sidebar {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  padding: 1rem;
+  border-radius: 28px;
+  background: var(--panel);
+}
+
+.brand-card {
+  padding: 1.25rem;
+  border-radius: 22px;
+  background: linear-gradient(145deg, rgba(0, 245, 255, 0.12), rgba(255, 43, 214, 0.1));
+}
+
+.eyebrow {
+  margin: 0 0 0.5rem;
+  color: var(--cyan);
+  font-family: "JetBrains Mono", monospace;
+  font-size: 0.75rem;
+  font-weight: 700;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+}
+
+h1,
+h2,
+h3,
+p {
+  margin-top: 0;
+}
+
+h1 {
+  margin-bottom: 0.75rem;
+  font-size: clamp(2.25rem, 7vw, 4.8rem);
+  line-height: 0.9;
+  text-transform: uppercase;
+}
+
+h2 {
+  max-width: 820px;
+  margin-bottom: 0;
+  font-size: clamp(1.75rem, 4vw, 4.2rem);
+  line-height: 0.98;
+}
+
+.brand-copy,
+.transmission-panel li {
+  color: var(--muted);
+  line-height: 1.6;
+}
+
+.release-link,
+.ghost-button,
+.danger-button,
+.primary-action {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 44px;
+  border-radius: 999px;
+  text-decoration: none;
+  transition: transform 180ms ease, border-color 180ms ease, box-shadow 180ms ease;
+}
+
+.release-link {
+  width: 100%;
+  margin-top: 1rem;
+  border: 1px solid rgba(140, 255, 0, 0.42);
+  color: var(--lime);
+  font-family: "JetBrains Mono", monospace;
+}
+
+.stats-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 0.75rem;
+}
+
+.stats-grid article {
+  padding: 1rem;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 18px;
+  background: rgba(255, 255, 255, 0.04);
+}
+
+.stats-grid span {
+  display: block;
+  color: var(--lime);
+  font-family: "JetBrains Mono", monospace;
+  font-size: 1.2rem;
+  font-weight: 700;
+}
+
+.stats-grid small {
+  color: var(--muted);
+}
+
+.primary-action {
+  border: 0;
+  background: linear-gradient(90deg, var(--cyan), var(--pink));
+  color: #050712;
+  font-weight: 800;
+}
+
+.notes-list {
+  display: grid;
+  gap: 0.75rem;
+  overflow: auto;
+  padding-right: 0.25rem;
+}
+
+.note-card {
+  width: 100%;
+  padding: 1rem;
+  border: 1px solid rgba(0, 245, 255, 0.14);
+  border-radius: 18px;
+  background: rgba(255, 255, 255, 0.04);
+  color: var(--text);
+  text-align: left;
+}
+
+.note-card.active {
+  border-color: var(--pink);
+  box-shadow: 0 0 22px rgba(255, 43, 214, 0.18);
+}
+
+.note-card strong,
+.note-card small {
+  display: block;
+}
+
+.note-card small {
+  margin-top: 0.35rem;
+  color: var(--muted);
+}
+
+.workspace {
+  display: grid;
+  grid-template-rows: auto 1fr auto;
+  gap: 1rem;
+  padding: 1rem;
+  border-radius: 28px;
+  background: var(--panel);
+}
+
+.topbar,
+.transmission-panel {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 1.25rem;
+  border-radius: 22px;
+  background: var(--panel-strong);
+}
+
+.topbar-actions {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: start;
+  gap: 0.75rem;
+}
+
+.ghost-button,
+.danger-button {
+  padding: 0 1rem;
+  background: transparent;
+}
+
+.ghost-button {
+  border: 1px solid rgba(0, 245, 255, 0.4);
+  color: var(--cyan);
+}
+
+.danger-button {
+  border: 1px solid rgba(255, 84, 112, 0.45);
+  color: var(--danger);
+}
+
+.editor-card {
+  display: grid;
+  gap: 0.85rem;
+  padding: 1.25rem;
+  border-radius: 22px;
+  background: rgba(5, 7, 18, 0.76);
+}
+
+label {
+  color: var(--muted);
+  font-weight: 700;
+}
+
+input,
+select,
+textarea {
+  width: 100%;
+  margin-top: 0.45rem;
+  border: 1px solid rgba(0, 245, 255, 0.18);
+  border-radius: 16px;
+  background: rgba(255, 255, 255, 0.055);
+  color: var(--text);
+  outline: none;
+}
+
+input,
+select {
+  min-height: 48px;
+  padding: 0 1rem;
+}
+
+textarea {
+  min-height: 44vh;
+  padding: 1rem;
+  resize: vertical;
+  line-height: 1.65;
+}
+
+input:focus,
+select:focus,
+textarea:focus {
+  border-color: var(--cyan);
+  box-shadow: 0 0 0 4px rgba(0, 245, 255, 0.1);
+}
+
+.meta-row {
+  display: grid;
+  grid-template-columns: 220px 1fr;
+  gap: 1rem;
+}
+
+.transmission-panel {
+  align-items: center;
+}
+
+.transmission-panel ul {
+  margin: 0;
+}
+
+.primary-action:hover,
+.release-link:hover,
+.ghost-button:hover,
+.danger-button:hover,
+.note-card:hover {
+  transform: translateY(-2px);
+}
+
+@media (max-width: 980px) {
+  .app-shell {
+    grid-template-columns: 1fr;
+  }
+
+  .sidebar {
+    max-height: none;
+  }
+
+  .topbar,
+  .transmission-panel {
+    flex-direction: column;
+  }
+}
+
+@media (max-width: 640px) {
+  .app-shell {
+    width: min(100% - 1rem, 1440px);
+    margin: 0.5rem auto;
+  }
+
+  .meta-row,
+  .stats-grid {
+    grid-template-columns: 1fr;
+  }
+}


### PR DESCRIPTION
### Motivation
- Replace the previous course-style README with a runnable static app prototype for Cipher Notes v1.4.1 that demonstrates a GitHub→App release flow. 
- Provide a local-first, neon-styled notes interface with autosave, tagging, priority, and portable export to showcase app behavior. 
- Ship a minimal, launch-ready prototype to make the project immediately interactive from `index.html`.

### Description
- Rewrote `README.md` to describe the app, add badges, run instructions, and list the main project files. 
- Added `index.html` which implements the app shell, editor UI, diagnostics, and links to the v1.4.1 release. 
- Added `styles.css` implementing the cyberpunk/neon visual system and responsive layout for the app. 
- Implemented `app.js` which provides starter notes, `localStorage` persistence, autosave on input, note creation/deletion, list rendering, word/note stats, timestamp formatting, and JSON export.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3b66c7853c83219d71f8b5a309a4f7)